### PR TITLE
Quick fix index

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -6,7 +6,6 @@
     ".eslintrc.js",
     ".travis.yml",
     "index.js",
-    "lib/client-model-indexes.js",
     "lib/client-functions.js"
   ],
   "extension": [

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const { clientModelIndexes } = require('@janiscommerce/client-creator');
 module.exports = {
 	core: {
 		//...ohter indexes
-		...clientModelIndexes
+		...clientModelIndexes()
 	}
 };
 ```

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const APICreate = require('./lib/api-create');
 const ModelClient = require('./lib/model-client');
 const ListenerCreated = require('./lib/listener-created');
-const clientFunctions = require('./lib/client-functions.json');
+const clientFunctions = require('./lib/client-functions');
 const clientModelIndexes = require('./lib/client-model-indexes');
 
 module.exports = {

--- a/lib/client-model-indexes.js
+++ b/lib/client-model-indexes.js
@@ -2,7 +2,6 @@
 
 const InstanceGetter = require('./helper/instance-getter');
 
-const Client = InstanceGetter.getModelClass('client');
 
 const codeUnique = {
 	name: 'code_unique',
@@ -10,6 +9,7 @@ const codeUnique = {
 	unique: true
 };
 
-module.exports = {
-	[Client.table]: [codeUnique]
+module.exports = () => {
+	const Client = InstanceGetter.getModelClass('client');
+	return { [Client.table]: [codeUnique] };
 };

--- a/tests/client-model-indexes.js
+++ b/tests/client-model-indexes.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('assert');
+const mockRequire = require('mock-require');
+const path = require('path');
+const ClientModelIndexes = require('../lib/client-model-indexes');
+const ClientModel = require('../lib/model-client');
+
+
+const fakeClientPath = path.join(process.cwd(), 'models', 'client');
+
+const codeUnique = {
+	name: 'code_unique',
+	key: { code: 1 },
+	unique: true
+};
+
+const clientIndex = { [ClientModel.table]: [codeUnique] };
+
+describe('ClientModelIndexes', () => {
+
+	it('should return the client index object when required', () => {
+		mockRequire(fakeClientPath, ClientModel);
+		assert.deepStrictEqual(ClientModelIndexes(), clientIndex);
+		mockRequire.stop(fakeClientPath);
+	});
+});


### PR DESCRIPTION
Se resolvió un bug que hacía un loop infinito cuando se requerían los modulos entre sí. 
Se resolvió un problema de dependencias. Se requería un archivo `.json` que no existía. 
**Changelog**

Added: 
- tests/client-model-indexes.js

Changed: 
- lib/client-model-indexes.js
- README.md
- index.js
