### PR TITLE
QUICK-fix-newclients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `databaseSettings` parameter for `postSaveHook()` method
+- `newClientsDatabaseKey` setting for new clients database config
 
 ### Changed
 - `Client` Model now set the new clients databaseKey from config

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ You should configure the database config in your service, in order to get the co
     }
   },
   "clients": {
-    "databaseKey": "newClients", // The new clients config databaseKey,
+    "newClientsDatabaseKey": "newClients", // The new clients config databaseKey ("newClients" by default)
+    "databaseKey": "newClients", // The databaseKey where store the new clients ("core" by default)
     "table": "clients" // The clients table where create the clients ("clients" by default)
   }
 }

--- a/lib/api-create.js
+++ b/lib/api-create.js
@@ -30,7 +30,7 @@ class ClientCreateAPI extends API {
 
 	async process({ clients: clientCodes } = this.data) {
 
-		const databaseSettings = Settings.get('database')[this.clientModel.databaseKey];
+		const databaseSettings = Settings.get('database')[this.clientModel.newClientsDatabaseKey];
 
 		const clientDatabase = {
 			dbHost: databaseSettings.host

--- a/lib/listener-created.js
+++ b/lib/listener-created.js
@@ -28,7 +28,7 @@ class ClientCreatedListener extends EventListener {
 
 	async process(clientCode = this.eventId) {
 
-		const databaseSettings = Settings.get('database')[this.clientModel.databaseKey];
+		const databaseSettings = Settings.get('database')[this.clientModel.newClientsDatabaseKey];
 
 		const clientDatabase = {
 			dbHost: databaseSettings.host,

--- a/lib/model-client.js
+++ b/lib/model-client.js
@@ -13,6 +13,10 @@ class Client extends Model {
 		return this.constructor.settings.databaseKey || 'core';
 	}
 
+	get newClientsDatabaseKey() {
+		return this.constructor.settings.newClientsDatabaseKey || 'newClients';
+	}
+
 	static get table() {
 		return this.settings.table || 'clients';
 	}

--- a/tests/api-create.js
+++ b/tests/api-create.js
@@ -35,7 +35,7 @@ describe('APIs', () => {
 				}
 			},
 			clients: {
-				databaseKey: 'newClients'
+				newClientsDatabaseKey: 'newClients'
 			}
 		};
 

--- a/tests/listener-created.js
+++ b/tests/listener-created.js
@@ -42,7 +42,7 @@ describe('Client Created Listener', async () => {
 			}
 		},
 		clients: {
-			databaseKey: 'newClients'
+			newClientsDatabaseKey: 'newClients'
 		}
 	};
 

--- a/tests/model-client.js
+++ b/tests/model-client.js
@@ -37,6 +37,28 @@ describe('ClientModel', () => {
 			assert.deepStrictEqual(clientModel.databaseKey, 'some-databaseKey');
 		});
 
+		it('should return the newClients as databaseKey for new clients when is not set in settings', () => {
+
+			sandbox.stub(Settings, 'get')
+				.returns({});
+
+			const clientModel = new ClientModel();
+
+			assert.deepStrictEqual(clientModel.newClientsDatabaseKey, 'newClients');
+		});
+
+		it('should return the new clients databaseKey setted in settings', () => {
+
+			sandbox.stub(Settings, 'get')
+				.returns({
+					newClientsDatabaseKey: 'some-databaseKey'
+				});
+
+			const clientModel = new ClientModel();
+
+			assert.deepStrictEqual(clientModel.newClientsDatabaseKey, 'some-databaseKey');
+		});
+
 		it('should return clients as table name when is not set in settings', () => {
 
 			sandbox.stub(Settings, 'get')


### PR DESCRIPTION
**DESCRIPCIÓN DEL REQUERIMIENTO**
- Solucionar el problema con la configuracion de los nuevos clientes con la configuracion de la conexion donde guardar los clientes, permitiendo setear la databaseKey para los clientes.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se realizaron los cambios solicitados