### PR TITLE
JCN-373-campos-opcionales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `additionalFields` getter in **ModelClient** for customizing client fields
 
 ## [5.2.5] - 2021-12-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `additionalFields` getter in **ModelClient** for customizing client fields
+- **API Client Created** and **EventListener Client Created** `postSaveHook()` receives the created client object in second parameter.
 
 ## [5.2.5] - 2021-12-02
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To skip the fetch of the credentials, it can be used the setting `skipFetchCrede
 }
 ```
 
-### ClientModel
+### :sparkles::new::sparkles: ClientModel
 At `./[MS_PATH]/models/client.js`
 
 ```js
@@ -155,6 +155,50 @@ At `./[MS_PATH]/models/client.js`
 const { ModelClient } = require('@janiscommerce/client-creator');
 
 module.exports = ModelClient;
+```
+
+:new: **Additional Fields**  
+Additional fields is a *getter* that allows the service to customize the clients fields, this is useful when a service needs their own custom data in clients.
+
+> #### :information_source: This will affect Client Created API and EventListener and also Client Updated EventListener behavior
+> When a client is created or modified, the current client will be obtained from ID service and **only the additional fields that exist in the getter** will be saved in the service along with the basic client fields.
+
+#### Example:
+```js
+'use strict';
+const { ModelClient } = require('@janiscommerce/client-creator');
+
+module.exports = class MyModelClient extends ModelClient {
+
+  static get additionalFields() {
+
+    return [
+      'myAdditionalField',
+      'anotherAdditionalField'
+    ]
+  }
+};
+```
+
+#### If a new client is created with these additional fields:
+```json
+{
+  "name": "Some Client",
+  "code": "some-client",
+  "myAdditionalField": "some-additional-data",
+  "anotherAdditionalField": "another-additional-data",
+  "unusedAdditionalField": "unused-data"
+}
+```
+
+#### The client will be saved in the service with only the specified additional fields:
+```json
+{
+  "name": "Some Client",
+  "code": "some-client",
+  "myAdditionalField": "some-additional-data",
+  "anotherAdditionalField": "another-additional-data"
+}
 ```
 
 ### APICreate

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Receives the clientCodes from the API.
 
 Parameters:
 - clientCodes `string Array`: The client created codes.
+- clients `object Array`: The clients created objects that were saved.
 
 ##### Example
 ```js
@@ -319,12 +320,16 @@ const { APICreate } = require('@janiscommerce/client-creator');
 
 class ClientCreateAPI extends APICreate {
 
-  async postSaveHook(clientCodes) {
+  async postSaveHook(clientCodes, clients) {
 
       await myPostSaveMethod(clientCodes);
 
       clientCodes.forEach(clientCode => {
           console.log(`Saved client ${clientCode}, now i'm gonna do something great`);
+      })
+
+      clients.forEach(({ databases, status }) => {
+        console.log(`This epic client has ${databases.length} databases and its status is ${status}`)
       })
     }
 }
@@ -333,11 +338,12 @@ module.exports = ClientCreateAPI;
 ```
 
 #### Listener Created   
-#### `postSaveHook(clientCode)`
+#### `postSaveHook(clientCode, client)`
 Receives the clientCode from the event.
 
 Parameters:
-- clientCode `string`: The client created code.gs of the created client.
+- clientCode `string`: The client created code of the created client.
+- client `object`: The client created object that was saved.
 
 It can be implemented as the example bellow:
 ##### Example
@@ -348,8 +354,9 @@ const { ListenerCreated } = require('@janiscommerce/client-creator');
 
 class ClientCreateListener extends ListenerCreated {
 
-  async postSaveHook(clientCode) {
+  async postSaveHook(clientCode, client) {
     console.log(`Saved client ${clientCode}, now i'm gonna do something great`);
+    console.log(`Saved client has ${client.databases.length} databases! Whoaaa`)
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ The `APICreate` and `listeners` have a hook for post processing the client or cl
 
 #### APICreate
 
-#### `postSaveHook(clientCodes)`
-Receives the clientCodes from the API.
+#### `postSaveHook(clientCodes, clients)`
+Receives the clientCodes and clients from the API.
 
 Parameters:
 - clientCodes `string Array`: The client created codes.
@@ -339,7 +339,7 @@ module.exports = ClientCreateAPI;
 
 #### Listener Created   
 #### `postSaveHook(clientCode, client)`
-Receives the clientCode from the event.
+Receives the clientCode and client from the event.
 
 Parameters:
 - clientCode `string`: The client created code of the created client.

--- a/lib/api-create.js
+++ b/lib/api-create.js
@@ -6,9 +6,9 @@ const { API } = require('@janiscommerce/api');
 const { struct } = require('@janiscommerce/superstruct');
 
 const { Invoker } = require('@janiscommerce/lambda');
-const MicroserviceCall = require('@janiscommerce/microservice-call');
 
 const ModelFetcher = require('./helpers/model-fetcher');
+const getClients = require('./helpers/get-clients');
 
 module.exports = class ClientCreateAPI extends API {
 
@@ -23,7 +23,7 @@ module.exports = class ClientCreateAPI extends API {
 		const ClientModel = ModelFetcher.get(); // se tiene que usar el modelo del servicio
 		const model = new ClientModel();
 
-		const clients = ClientModel.validateAdditionalFields() ? await this.getClients(clientCodes) : clientCodes.map(code => ({ code }));
+		const clients = ClientModel.validateAdditionalFields() ? await getClients(clientCodes) : clientCodes.map(code => ({ code }));
 
 		if(!clients) {
 			logger.error('Unable to get Janis ID clients, they won\'t be created.');
@@ -47,19 +47,5 @@ module.exports = class ClientCreateAPI extends API {
 	 */
 	async postSaveHook() {
 		return true;
-	}
-
-	async getClients(clientCodes) {
-
-		const msCall = new MicroserviceCall();
-
-		const { statusCode, body } = await msCall.safeList('id', 'client', { filters: { clientCode: clientCodes } });
-
-		if(statusCode >= 500) {
-			const errorMessage = body && body.message ? `${body.message}` : 'Service failed';
-			throw new Error(`Failed to get Janis ID clients: ${errorMessage}`);
-		}
-
-		return statusCode < 400 && body.length && body;
 	}
 };

--- a/lib/api-create.js
+++ b/lib/api-create.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const logger = require('lllog')();
+
 const { API } = require('@janiscommerce/api');
 const { struct } = require('@janiscommerce/superstruct');
 
 const { Invoker } = require('@janiscommerce/lambda');
+const MicroserviceCall = require('@janiscommerce/microservice-call');
 
 const ModelFetcher = require('./helpers/model-fetcher');
-const ModelClient = require('./model-client');
 
 module.exports = class ClientCreateAPI extends API {
 
@@ -18,17 +20,26 @@ module.exports = class ClientCreateAPI extends API {
 
 	async process({ clients: clientCodes } = this.data) {
 
-		const clientsToCreate = await ModelClient.formatForCreate(clientCodes);
-
 		const ClientModel = ModelFetcher.get(); // se tiene que usar el modelo del servicio
-
 		const model = new ClientModel();
+
+		const clients = await this.getClients(clientCodes);
+
+		if(!clients) {
+			logger.error('Unable to get Janis ID clients, they won\'t be created.');
+			return;
+		}
+
+		if(clients.length !== clientCodes.length)
+			logger.warn('Some clients couldn\'t be get from Janis ID service, they won\'t be created.');
+
+		const clientsToCreate = await ClientModel.formatForCreate(clients);
 
 		await model.multiSave(clientsToCreate);
 
 		await Invoker.call('MongoDBIndexCreator');
 
-		return this.postSaveHook(clientCodes);
+		return this.postSaveHook(clientCodes, clientsToCreate);
 	}
 
 	/**
@@ -36,5 +47,19 @@ module.exports = class ClientCreateAPI extends API {
 	 */
 	async postSaveHook() {
 		return true;
+	}
+
+	async getClients(clientCodes) {
+
+		const msCall = new MicroserviceCall();
+
+		const { statusCode, body } = await msCall.safeList('id', 'client', { filters: { clientCode: clientCodes } });
+
+		if(statusCode >= 500) {
+			const errorMessage = body && body.message ? `${body.message}` : 'Service failed';
+			throw new Error(`Failed to get Janis ID clients: ${errorMessage}`);
+		}
+
+		return statusCode < 400 && body.length && body;
 	}
 };

--- a/lib/api-create.js
+++ b/lib/api-create.js
@@ -23,7 +23,7 @@ module.exports = class ClientCreateAPI extends API {
 		const ClientModel = ModelFetcher.get(); // se tiene que usar el modelo del servicio
 		const model = new ClientModel();
 
-		const clients = ClientModel.additionalFields ? await this.getClients(clientCodes) : clientCodes.map(code => ({ code }));
+		const clients = ClientModel.validateAdditionalFields() ? await this.getClients(clientCodes) : clientCodes.map(code => ({ code }));
 
 		if(!clients) {
 			logger.error('Unable to get Janis ID clients, they won\'t be created.');

--- a/lib/api-create.js
+++ b/lib/api-create.js
@@ -31,7 +31,7 @@ module.exports = class ClientCreateAPI extends API {
 		}
 
 		if(clients.length !== clientCodes.length)
-			logger.warn('Some clients couldn\'t be get from Janis ID service, they won\'t be created.');
+			logger.warn('Some clients couldn\'t be obtained from Janis ID service, they won\'t be created.');
 
 		const clientsToCreate = await ClientModel.formatForCreate(clients);
 

--- a/lib/api-create.js
+++ b/lib/api-create.js
@@ -23,7 +23,7 @@ module.exports = class ClientCreateAPI extends API {
 		const ClientModel = ModelFetcher.get(); // se tiene que usar el modelo del servicio
 		const model = new ClientModel();
 
-		const clients = await this.getClients(clientCodes);
+		const clients = ClientModel.additionalFields ? await this.getClients(clientCodes) : clientCodes.map(code => ({ code }));
 
 		if(!clients) {
 			logger.error('Unable to get Janis ID clients, they won\'t be created.');

--- a/lib/helpers/client-formatter.js
+++ b/lib/helpers/client-formatter.js
@@ -32,7 +32,7 @@ module.exports = class ClientFormatter {
 
 			additionalFields.forEach(field => {
 
-				if(client[field])
+				if(typeof client[field] !== 'undefined')
 					formattedClient[field] = client[field];
 			});
 		}

--- a/lib/helpers/client-formatter.js
+++ b/lib/helpers/client-formatter.js
@@ -28,14 +28,14 @@ module.exports = class ClientFormatter {
 			status: this.statusActive
 		};
 
-		if(!additionalFields)
-			return formattedClient;
+		if(additionalFields) {
 
-		additionalFields.forEach(field => {
+			additionalFields.forEach(field => {
 
-			if(client[field])
-				formattedClient[field] = client[field];
-		});
+				if(client[field])
+					formattedClient[field] = client[field];
+			});
+		}
 
 		return formattedClient;
 	}

--- a/lib/helpers/client-formatter.js
+++ b/lib/helpers/client-formatter.js
@@ -20,12 +20,24 @@ module.exports = class ClientFormatter {
 		return this._statusActive;
 	}
 
-	static format(code) {
-		return {
+	static format({ code, ...client }, additionalFields) {
+
+		const formattedClient = {
 			code,
 			databases: this.prepareDatabases(code),
 			status: this.statusActive
 		};
+
+		if(!additionalFields)
+			return formattedClient;
+
+		Object.entries(client).forEach(([key, value]) => {
+
+			if(additionalFields.includes(key))
+				formattedClient[key] = value;
+		});
+
+		return formattedClient;
 	}
 
 	static prepareDatabases(code) {

--- a/lib/helpers/client-formatter.js
+++ b/lib/helpers/client-formatter.js
@@ -31,10 +31,10 @@ module.exports = class ClientFormatter {
 		if(!additionalFields)
 			return formattedClient;
 
-		Object.entries(client).forEach(([key, value]) => {
+		additionalFields.forEach(field => {
 
-			if(additionalFields.includes(key))
-				formattedClient[key] = value;
+			if(client[field])
+				formattedClient[field] = client[field];
 		});
 
 		return formattedClient;

--- a/lib/helpers/get-clients.js
+++ b/lib/helpers/get-clients.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const MicroserviceCall = require('@janiscommerce/microservice-call');
+
+module.exports = async clientCodes => {
+
+	const msCall = new MicroserviceCall();
+
+	const { statusCode, body } = await msCall.safeList('id', 'client', { filters: { clientCode: clientCodes }, limit: clientCodes.length });
+
+	if(statusCode >= 500) {
+		const errorMessage = body && body.message ? `${body.message}` : 'Service failed';
+		throw new Error(`Failed to get Janis ID clients: ${errorMessage}`);
+	}
+
+	return statusCode < 400 && body.length && body;
+};

--- a/lib/listener-created.js
+++ b/lib/listener-created.js
@@ -24,7 +24,7 @@ module.exports = class ClientCreatedListener extends EventListener {
 		const ClientModel = ModelFetcher.get(); // se tiene que usar el modelo del servicio
 		const model = new ClientModel();
 
-		const client = ClientModel.additionalFields ? await this.getClient(clientCode) : { code: clientCode };
+		const client = ClientModel.validateAdditionalFields() ? await this.getClient(clientCode) : { code: clientCode };
 
 		if(!client) {
 			logger.error('Unable to get Janis ID client, it won\'t be created.');

--- a/lib/listener-created.js
+++ b/lib/listener-created.js
@@ -24,7 +24,7 @@ module.exports = class ClientCreatedListener extends EventListener {
 		const ClientModel = ModelFetcher.get(); // se tiene que usar el modelo del servicio
 		const model = new ClientModel();
 
-		const client = await this.getClient(clientCode);
+		const client = ClientModel.additionalFields ? await this.getClient(clientCode) : { code: clientCode };
 
 		if(!client) {
 			logger.error('Unable to get Janis ID client, it won\'t be created.');

--- a/lib/listener-created.js
+++ b/lib/listener-created.js
@@ -5,9 +5,9 @@ const logger = require('lllog')();
 const { EventListener } = require('@janiscommerce/event-listener');
 
 const MongoDBIndexCreator = require('@janiscommerce/mongodb-index-creator');
-const MicroserviceCall = require('@janiscommerce/microservice-call');
 
 const ModelFetcher = require('./helpers/model-fetcher');
+const getClients = require('./helpers/get-clients');
 
 const mongoDBIndexCreator = new MongoDBIndexCreator();
 
@@ -41,17 +41,8 @@ module.exports = class ClientCreatedListener extends EventListener {
 	}
 
 	async getClient(clientCode) {
-
-		const msCall = new MicroserviceCall();
-
-		const { statusCode, body } = await msCall.safeList('id', 'client', { filters: { clientCode }, limit: 1 });
-
-		if(statusCode >= 500) {
-			const errorMessage = body && body.message ? `${body.message}` : 'Service failed';
-			throw new Error(`Failed to get Janis ID client: ${errorMessage}`);
-		}
-
-		return statusCode < 400 && body[0];
+		const client = await getClients([clientCode]);
+		return client && client[0];
 	}
 
 	/**

--- a/lib/listener-created.js
+++ b/lib/listener-created.js
@@ -1,11 +1,13 @@
 'use strict';
 
+const logger = require('lllog')();
+
 const { EventListener } = require('@janiscommerce/event-listener');
 
 const MongoDBIndexCreator = require('@janiscommerce/mongodb-index-creator');
+const MicroserviceCall = require('@janiscommerce/microservice-call');
 
 const ModelFetcher = require('./helpers/model-fetcher');
-const ModelClient = require('./model-client');
 
 const mongoDBIndexCreator = new MongoDBIndexCreator();
 
@@ -19,17 +21,37 @@ module.exports = class ClientCreatedListener extends EventListener {
 
 		const clientCode = this.eventId;
 
-		const formattedClient = await ModelClient.formatForCreate(clientCode);
-
 		const ClientModel = ModelFetcher.get(); // se tiene que usar el modelo del servicio
-
 		const model = new ClientModel();
+
+		const client = await this.getClient(clientCode);
+
+		if(!client) {
+			logger.error('Unable to get Janis ID client, it won\'t be created.');
+			return;
+		}
+
+		const [formattedClient] = await ClientModel.formatForCreate([client]);
 
 		await model.save(formattedClient);
 
 		await mongoDBIndexCreator.executeForClientCode(clientCode);
 
-		return this.postSaveHook(clientCode);
+		return this.postSaveHook(clientCode, formattedClient);
+	}
+
+	async getClient(clientCode) {
+
+		const msCall = new MicroserviceCall();
+
+		const { statusCode, body } = await msCall.safeList('id', 'client', { filters: { clientCode }, limit: 1 });
+
+		if(statusCode >= 500) {
+			const errorMessage = body && body.message ? `${body.message}` : 'Service failed';
+			throw new Error(`Failed to get Janis ID client: ${errorMessage}`);
+		}
+
+		return statusCode < 400 && body[0];
 	}
 
 	/**

--- a/lib/listener-updated.js
+++ b/lib/listener-updated.js
@@ -51,10 +51,7 @@ module.exports = class ClientUpdatedListener extends EventListener {
 		const fieldsToUpdate = { status };
 		const fieldsToRemove = {};
 
-		if(ClientModel.additionalFields) {
-
-			if(!Array.isArray(ClientModel.additionalFields))
-				throw new Error('Invalid getter \'additionalFields\': Should be an array.');
+		if(ClientModel.validateAdditionalFields()) {
 
 			ClientModel.additionalFields.forEach(fieldName => {
 

--- a/lib/listener-updated.js
+++ b/lib/listener-updated.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const logger = require('lllog')();
+
 const { EventListener } = require('@janiscommerce/event-listener');
 const MicroserviceCall = require('@janiscommerce/microservice-call');
 
@@ -17,8 +19,10 @@ module.exports = class ClientUpdatedListener extends EventListener {
 
 		const updatedClient = await this.getUpdatedClient(clientId);
 
-		if(!updatedClient)
+		if(!updatedClient) {
+			logger.error('Unable to get Janis ID client, it won\'t be updated.');
 			return;
+		}
 
 		await this.updateServiceClient(updatedClient);
 
@@ -29,26 +33,39 @@ module.exports = class ClientUpdatedListener extends EventListener {
 
 		const msCall = new MicroserviceCall();
 
-		const response = await msCall.safeCall('id', 'client', 'get', null, null, { id: clientId });
+		const { statusCode, body } = await msCall.safeCall('id', 'client', 'get', null, null, { id: clientId });
 
-		if(msCall.shouldRetry(response)) {
-			const msCallError = (response.body && response.body.message) ? `${response.body.message}` : 'Unable to get Janis ID client';
-			throw new Error(msCallError);
+		if(statusCode >= 500) {
+			const errorMessage = body && body.message ? `${body.message}` : 'Service failed';
+			throw new Error(`Failed to get Janis ID client: ${errorMessage}`);
 		}
 
-		return response.statusCode < 400 && response.body;
+		return statusCode < 400 && body;
 	}
 
-	updateServiceClient(updatedClient) {
+	updateServiceClient({ code, status, ...updatedClient }) {
 
 		const ClientModel = ModelFetcher.get();
 		const model = new ClientModel();
 
-		return model.update({
-			status: updatedClient.status
-		}, {
-			code: updatedClient.code
-		});
+		const fieldsToUpdate = { status };
+		const fieldsToRemove = {};
+
+		if(ClientModel.additionalFields) {
+
+			if(!Array.isArray(ClientModel.additionalFields))
+				throw new Error('Invalid getter \'additionalFields\': Should be an array.');
+
+			ClientModel.additionalFields.forEach(fieldName => {
+
+				if(updatedClient[fieldName])
+					fieldsToUpdate[fieldName] = updatedClient[fieldName];
+				else
+					fieldsToRemove[fieldName] = '';
+			});
+		}
+
+		return model.update({ ...fieldsToUpdate, ...Object.keys(fieldsToRemove).length && { $unset: fieldsToRemove } }, { code });
 	}
 
 	/**

--- a/lib/listener-updated.js
+++ b/lib/listener-updated.js
@@ -55,7 +55,7 @@ module.exports = class ClientUpdatedListener extends EventListener {
 
 			ClientModel.additionalFields.forEach(fieldName => {
 
-				if(updatedClient[fieldName])
+				if(typeof updatedClient[fieldName] !== 'undefined')
 					fieldsToUpdate[fieldName] = updatedClient[fieldName];
 				else
 					fieldsToRemove[fieldName] = '';

--- a/lib/model-client.js
+++ b/lib/model-client.js
@@ -32,7 +32,7 @@ module.exports = class Client extends Model {
 
 	/**
 	 * Get additional fields
-	 * @returns {undefined} returns undefined by default
+	 * @returns {string[]|undefined} returns undefined by default
 	 */
 	static get additionalFields() {
 		return undefined;

--- a/lib/model-client.js
+++ b/lib/model-client.js
@@ -30,6 +30,10 @@ module.exports = class Client extends Model {
 		return ['databases'];
 	}
 
+	/**
+	 * Get additional fields
+	 * @returns {undefined} returns undefined by default
+	 */
 	static get additionalFields() {
 		return undefined;
 	}

--- a/lib/model-client.js
+++ b/lib/model-client.js
@@ -30,17 +30,17 @@ module.exports = class Client extends Model {
 		return ['databases'];
 	}
 
-	static async formatForCreate(clientCodes) {
+	static get additionalFields() {
+		return undefined;
+	}
+
+	static async formatForCreate(clients) {
+
+		if(this.additionalFields && !Array.isArray(this.additionalFields))
+			throw new Error('Invalid getter \'additionalFields\': Should be an array.');
 
 		await ClientFormatter.prepareSettings();
 
-		const isMultiple = Array.isArray(clientCodes);
-
-		if(!isMultiple)
-			clientCodes = [clientCodes];
-
-		const formattedClients = clientCodes.map(clientCode => ClientFormatter.format(clientCode));
-
-		return isMultiple ? formattedClients : formattedClients[0];
+		return clients.map(client => ClientFormatter.format(client, this.additionalFields));
 	}
 };

--- a/lib/model-client.js
+++ b/lib/model-client.js
@@ -34,13 +34,19 @@ module.exports = class Client extends Model {
 		return undefined;
 	}
 
-	static async formatForCreate(clients) {
+	static validateAdditionalFields() {
 
-		if(this.additionalFields && !Array.isArray(this.additionalFields))
+		if(!this.additionalFields)
+			return;
+
+		if(!Array.isArray(this.additionalFields))
 			throw new Error('Invalid getter \'additionalFields\': Should be an array.');
 
-		await ClientFormatter.prepareSettings();
+		return !!this.additionalFields.length;
+	}
 
+	static async formatForCreate(clients) {
+		await ClientFormatter.prepareSettings();
 		return clients.map(client => ClientFormatter.format(client, this.additionalFields));
 	}
 };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@janiscommerce/model": "^5.5.0",
     "@janiscommerce/mongodb-index-creator": "^2.3.0",
     "@janiscommerce/settings": "^1.0.1",
-    "@janiscommerce/superstruct": "^1.2.0"
+    "@janiscommerce/superstruct": "^1.2.0",
+    "lllog": "^1.1.2"
   }
 }

--- a/tests/api-create.js
+++ b/tests/api-create.js
@@ -106,7 +106,7 @@ describe('Client Create API', () => {
 				stubGetSecret(sandbox);
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
+					.withArgs('id', 'client', { filters: { clientCode: clients }, limit: clients.length })
 					.resolves({ statusCode: 200, body: clientsToSaveWithAdditionalFields });
 
 				sandbox.stub(ModelClient.prototype, 'multiSave')
@@ -122,7 +122,11 @@ describe('Client Create API', () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', {
+					filters: { clientCode: clients },
+					limit: clients.length
+				});
+
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clientsToSaveWithAdditionalFields);
 				sandbox.assert.calledOnceWithExactly(Invoker.call, 'MongoDBIndexCreator');
 
@@ -348,7 +352,7 @@ describe('Client Create API', () => {
 				stubGetSecret(sandbox);
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
+					.withArgs('id', 'client', { filters: { clientCode: clients }, limit: clients.length })
 					.resolves({ statusCode: 400, body: {} });
 
 				sandbox.spy(ModelClient.prototype, 'multiSave');
@@ -360,7 +364,11 @@ describe('Client Create API', () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', {
+					filters: { clientCode: clients },
+					limit: clients.length
+				});
+
 				sandbox.assert.notCalled(ModelClient.prototype.multiSave);
 				sandbox.assert.notCalled(Invoker.call);
 				sandbox.assert.notCalled(APICreate.prototype.postSaveHook);
@@ -389,7 +397,7 @@ describe('Client Create API', () => {
 				stubGetSecret(sandbox);
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
+					.withArgs('id', 'client', { filters: { clientCode: clients }, limit: clients.length })
 					.resolves({ statusCode: 200, body: [clientsToSave[0]] });
 
 				sandbox.stub(ModelClient.prototype, 'multiSave')
@@ -405,7 +413,11 @@ describe('Client Create API', () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', {
+					filters: { clientCode: clients },
+					limit: clients.length
+				});
+
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, [clientsToSave[0]]);
 				sandbox.assert.calledOnceWithExactly(Invoker.call, 'MongoDBIndexCreator');
 
@@ -439,7 +451,7 @@ describe('Client Create API', () => {
 				stubGetSecret(sandbox);
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
+					.withArgs('id', 'client', { filters: { clientCode: clients }, limit: clients.length })
 					.resolves({ statusCode: 200, body: [] });
 
 				sandbox.spy(ModelClient.prototype, 'multiSave');
@@ -451,7 +463,11 @@ describe('Client Create API', () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', {
+					filters: { clientCode: clients },
+					limit: clients.length
+				});
+
 				sandbox.assert.notCalled(ModelClient.prototype.multiSave);
 				sandbox.assert.notCalled(Invoker.call);
 				sandbox.assert.notCalled(APICreate.prototype.postSaveHook);
@@ -480,7 +496,7 @@ describe('Client Create API', () => {
 				stubGetSecret(sandbox);
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
+					.withArgs('id', 'client', { filters: { clientCode: clients }, limit: clients.length })
 					.resolves({ statusCode: 500, body: {} });
 
 				sandbox.spy(ModelClient.prototype, 'multiSave');
@@ -492,7 +508,11 @@ describe('Client Create API', () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', {
+					filters: { clientCode: clients },
+					limit: clients.length
+				});
+
 				sandbox.assert.notCalled(ModelClient.prototype.multiSave);
 				sandbox.assert.notCalled(Invoker.call);
 				sandbox.assert.notCalled(APICreate.prototype.postSaveHook);
@@ -521,7 +541,7 @@ describe('Client Create API', () => {
 				stubGetSecret(sandbox);
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
+					.withArgs('id', 'client', { filters: { clientCode: clients }, limit: clients.length })
 					.resolves({ statusCode: 500, body: { message: 'Some API Error' } });
 
 				sandbox.spy(ModelClient.prototype, 'multiSave');
@@ -533,7 +553,11 @@ describe('Client Create API', () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', {
+					filters: { clientCode: clients },
+					limit: clients.length
+				});
+
 				sandbox.assert.notCalled(ModelClient.prototype.multiSave);
 				sandbox.assert.notCalled(Invoker.call);
 				sandbox.assert.notCalled(APICreate.prototype.postSaveHook);

--- a/tests/api-create.js
+++ b/tests/api-create.js
@@ -59,10 +59,6 @@ describe('Client Create API', () => {
 
 				stubGetSecret(sandbox);
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.resolves(true);
 
@@ -76,7 +72,6 @@ describe('Client Create API', () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clientsToSave);
 				sandbox.assert.calledOnceWithExactly(Invoker.call, 'MongoDBIndexCreator');
 
@@ -88,7 +83,8 @@ describe('Client Create API', () => {
 
 				stopMock();
 			}
-		}, {
+		},
+		{
 			description: 'Should save all the received new clients to clients DB including additional fields',
 			request: {
 				data: { clients }
@@ -138,7 +134,8 @@ describe('Client Create API', () => {
 
 				stopMock();
 			}
-		}, {
+		},
+		{
 			description: 'Should save all the received new clients to clients DB when no settings found in file',
 			request: {
 				data: { clients }
@@ -157,10 +154,6 @@ describe('Client Create API', () => {
 
 				stubGetSecret(sandbox);
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.resolves(true);
 
@@ -176,7 +169,6 @@ describe('Client Create API', () => {
 
 				const expectedClientsToSave = clients.map(code => prepareFakeClient(code, false, false));
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, expectedClientsToSave);
 				sandbox.assert.calledOnceWithExactly(Invoker.call, 'MongoDBIndexCreator');
 
@@ -188,7 +180,8 @@ describe('Client Create API', () => {
 
 				stopMock();
 			}
-		}, {
+		},
+		{
 			description: 'Should save clients after fetching database credentials',
 			request: {
 				data: { clients }
@@ -216,10 +209,6 @@ describe('Client Create API', () => {
 					}
 				});
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.resolves(true);
 
@@ -233,12 +222,12 @@ describe('Client Create API', () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clients.map(code => prepareFakeClient(code, true)));
 
 				stopMock();
 			}
-		}, {
+		},
+		{
 			description: 'Should skip fetching credentials if environment is local',
 			request: {
 				data: { clients }
@@ -256,10 +245,6 @@ describe('Client Create API', () => {
 
 				stubGetSecret(sandbox);
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.resolves(true);
 
@@ -273,12 +258,11 @@ describe('Client Create API', () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clientsToSave);
-
 				stopMock();
 			}
-		}, {
+		},
+		{
 			description: 'Should save clients when SecretsManager throws an Error',
 			request: {
 				data: { clients }
@@ -296,10 +280,6 @@ describe('Client Create API', () => {
 
 				secretThrows(sandbox);
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.resolves(true);
 
@@ -310,13 +290,11 @@ describe('Client Create API', () => {
 
 			},
 			after: (res, sandbox) => {
-
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clientsToSave);
-
 				stopMock();
 			}
-		}, {
+		},
+		{
 			description: 'Should save clients when SecretsManager getValue rejects',
 			request: {
 				data: { clients }
@@ -334,10 +312,6 @@ describe('Client Create API', () => {
 
 				getValueRejects(sandbox);
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.resolves(true);
 
@@ -348,13 +322,11 @@ describe('Client Create API', () => {
 
 			},
 			after: (res, sandbox) => {
-
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clientsToSave);
-
 				stopMock();
 			}
-		}, {
+		},
+		{
 			description: 'Should return 200 when MicroserviceCall can\'t get clients from ID Service',
 			request: {
 				data: { clients }
@@ -365,6 +337,9 @@ describe('Client Create API', () => {
 				delete ClientFormatter.settings;
 
 				mockModelClient();
+
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
 
 				sandbox.stub(Settings, 'get').returns(fakeDBSettings);
 
@@ -403,6 +378,9 @@ describe('Client Create API', () => {
 				delete ClientFormatter.settings;
 
 				mockModelClient();
+
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
 
 				sandbox.stub(Settings, 'get').returns(fakeDBSettings);
 
@@ -451,6 +429,9 @@ describe('Client Create API', () => {
 
 				mockModelClient();
 
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
+
 				sandbox.stub(Settings, 'get').returns(fakeDBSettings);
 
 				setEnv();
@@ -489,6 +470,9 @@ describe('Client Create API', () => {
 
 				mockModelClient();
 
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
+
 				sandbox.stub(Settings, 'get').returns(fakeDBSettings);
 
 				setEnv();
@@ -526,6 +510,9 @@ describe('Client Create API', () => {
 				delete ClientFormatter.settings;
 
 				mockModelClient();
+
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
 
 				sandbox.stub(Settings, 'get').returns(fakeDBSettings);
 
@@ -571,10 +558,6 @@ describe('Client Create API', () => {
 
 				stubGetSecret(sandbox);
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.rejects();
 
@@ -585,7 +568,6 @@ describe('Client Create API', () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clientsToSave);
 				sandbox.assert.notCalled(Invoker.call);
 
@@ -609,10 +591,6 @@ describe('Client Create API', () => {
 
 				stubGetSecret(sandbox);
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: clients } })
-					.resolves({ statusCode: 200, body: clientsToSave });
-
 				sandbox.stub(ModelClient.prototype, 'multiSave')
 					.resolves();
 
@@ -623,7 +601,6 @@ describe('Client Create API', () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: clients } });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.multiSave, clientsToSave);
 				sandbox.assert.calledOnceWithExactly(Invoker.call, 'MongoDBIndexCreator');
 
@@ -669,13 +646,11 @@ describe('Client Create API', () => {
 
 				stubGetSecret(sandbox);
 
-				sandbox.spy(MicroserviceCall.prototype, 'safeList');
 				sandbox.spy(ModelClient.prototype, 'multiSave');
 				sandbox.spy(Invoker, 'call');
 			},
 			after: (res, sandbox) => {
 
-				sandbox.assert.notCalled(MicroserviceCall.prototype.safeList);
 				sandbox.assert.notCalled(ModelClient.prototype.multiSave);
 				sandbox.assert.notCalled(Invoker.call);
 

--- a/tests/api-create.js
+++ b/tests/api-create.js
@@ -35,7 +35,11 @@ describe('Client Create API', () => {
 	const clients = ['foo', 'bar'];
 
 	const clientsToSave = clients.map(code => prepareFakeClient(code));
-	const clientsToSaveWithAdditionalFields = clientsToSave.map(client => ({ ...client, extraField: 'some-data' }));
+
+	const clientsToSaveWithAdditionalFields = [
+		{ ...clientsToSave[0], extraField: 'some-data' },
+		{ ...clientsToSave[1], extraField: 0 }
+	];
 
 	const janisServiceName = 'some-service-name';
 	process.env.JANIS_SERVICE_NAME = janisServiceName;

--- a/tests/listener-created.js
+++ b/tests/listener-created.js
@@ -379,10 +379,6 @@ describe('Client Created Listener', async () => {
 
 				delete ClientFormatter.settings;
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [{ ...fakeClient, extraField: 'some-data', randomField: 'foobar' }] });
-
 				mockModelClient();
 
 				sandbox.stub(ModelClient, 'additionalFields')
@@ -394,6 +390,7 @@ describe('Client Created Listener', async () => {
 
 				stubGetSecret(sandbox);
 
+				sandbox.spy(MicroserviceCall.prototype, 'safeList');
 				sandbox.spy(ModelClient.prototype, 'save');
 				sandbox.spy(MongoDBIndexCreator.prototype, 'executeForClientCode');
 				sandbox.spy(ListenerCreated.prototype, 'postSaveHook');
@@ -402,7 +399,7 @@ describe('Client Created Listener', async () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
+				sandbox.assert.notCalled(MicroserviceCall.prototype.safeList);
 				sandbox.assert.notCalled(ModelClient.prototype.save);
 				sandbox.assert.notCalled(MongoDBIndexCreator.prototype.executeForClientCode);
 				sandbox.assert.notCalled(ListenerCreated.prototype.postSaveHook);

--- a/tests/listener-created.js
+++ b/tests/listener-created.js
@@ -170,7 +170,7 @@ describe('Client Created Listener', async () => {
 				delete ClientFormatter.settings;
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
+					.withArgs('id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 })
 					.resolves({ statusCode: 200, body: [{ ...fakeClient, extraField: 'some-data', randomField: 'foobar' }] });
 
 				mockModelClient();
@@ -198,7 +198,7 @@ describe('Client Created Listener', async () => {
 
 				const expectedClientToSave = { ...fakeClient, extraField: 'some-data' };
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, expectedClientToSave);
 				sandbox.assert.calledOnceWithExactly(MongoDBIndexCreator.prototype.executeForClientCode, validEvent.id);
 				sandbox.assert.calledOnceWithExactly(ListenerCreated.prototype.postSaveHook, validEvent.id, expectedClientToSave);
@@ -216,7 +216,7 @@ describe('Client Created Listener', async () => {
 				delete ClientFormatter.settings;
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
+					.withArgs('id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 })
 					.resolves({ statusCode: 400, body: {} });
 
 				mockModelClient();
@@ -239,7 +239,7 @@ describe('Client Created Listener', async () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 });
 				sandbox.assert.notCalled(ModelClient.prototype.save);
 				sandbox.assert.notCalled(MongoDBIndexCreator.prototype.executeForClientCode);
 				sandbox.assert.notCalled(ListenerCreated.prototype.postSaveHook);
@@ -257,7 +257,7 @@ describe('Client Created Listener', async () => {
 				delete ClientFormatter.settings;
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
+					.withArgs('id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 })
 					.resolves({ statusCode: 200, body: [] });
 
 				mockModelClient();
@@ -280,7 +280,7 @@ describe('Client Created Listener', async () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 });
 				sandbox.assert.notCalled(ModelClient.prototype.save);
 				sandbox.assert.notCalled(MongoDBIndexCreator.prototype.executeForClientCode);
 				sandbox.assert.notCalled(ListenerCreated.prototype.postSaveHook);
@@ -298,7 +298,7 @@ describe('Client Created Listener', async () => {
 				delete ClientFormatter.settings;
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
+					.withArgs('id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 })
 					.resolves({ statusCode: 500, body: {} });
 
 				mockModelClient();
@@ -321,7 +321,7 @@ describe('Client Created Listener', async () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 });
 				sandbox.assert.notCalled(ModelClient.prototype.save);
 				sandbox.assert.notCalled(MongoDBIndexCreator.prototype.executeForClientCode);
 				sandbox.assert.notCalled(ListenerCreated.prototype.postSaveHook);
@@ -339,7 +339,7 @@ describe('Client Created Listener', async () => {
 				delete ClientFormatter.settings;
 
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
+					.withArgs('id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 })
 					.resolves({ statusCode: 500, body: { message: 'Some API Error' } });
 
 				mockModelClient();
@@ -362,7 +362,7 @@ describe('Client Created Listener', async () => {
 
 				secretsNotCalled(sandbox);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
+				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: [validEvent.id] }, limit: 1 });
 				sandbox.assert.notCalled(ModelClient.prototype.save);
 				sandbox.assert.notCalled(MongoDBIndexCreator.prototype.executeForClientCode);
 				sandbox.assert.notCalled(ListenerCreated.prototype.postSaveHook);

--- a/tests/listener-created.js
+++ b/tests/listener-created.js
@@ -67,10 +67,6 @@ describe('Client Created Listener', async () => {
 
 				delete ClientFormatter.settings;
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
-
 				mockModelClient();
 
 				sandbox.stub(ModelClient.prototype, 'save')
@@ -89,7 +85,6 @@ describe('Client Created Listener', async () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, fakeClient);
 				sandbox.assert.notCalled(MongoDBIndexCreator.prototype.executeForClientCode);
 
@@ -105,10 +100,6 @@ describe('Client Created Listener', async () => {
 
 				delete ClientFormatter.settings;
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
-
 				mockModelClient();
 
 				sandbox.stub(ModelClient.prototype, 'save')
@@ -127,7 +118,6 @@ describe('Client Created Listener', async () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, fakeClient);
 				sandbox.assert.calledOnce(MongoDBIndexCreator.prototype.executeForClientCode);
 
@@ -142,10 +132,6 @@ describe('Client Created Listener', async () => {
 			before: sandbox => {
 
 				delete ClientFormatter.settings;
-
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
 
 				mockModelClient();
 
@@ -167,7 +153,6 @@ describe('Client Created Listener', async () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, fakeClient);
 				sandbox.assert.calledOnceWithExactly(MongoDBIndexCreator.prototype.executeForClientCode, validEvent.id);
 				sandbox.assert.calledOnceWithExactly(ListenerCreated.prototype.postSaveHook, validEvent.id, fakeClient);
@@ -184,14 +169,14 @@ describe('Client Created Listener', async () => {
 
 				delete ClientFormatter.settings;
 
-				sandbox.stub(ModelClient, 'additionalFields')
-					.get(() => ['extraField']);
-
 				sandbox.stub(MicroserviceCall.prototype, 'safeList')
 					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
 					.resolves({ statusCode: 200, body: [{ ...fakeClient, extraField: 'some-data', randomField: 'foobar' }] });
 
 				mockModelClient();
+
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
 
 				sandbox.stub(ModelClient.prototype, 'save')
 					.resolves('5dea9fc691240d00084083f9');
@@ -236,6 +221,9 @@ describe('Client Created Listener', async () => {
 
 				mockModelClient();
 
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
+
 				sandbox.spy(ModelClient.prototype, 'save');
 
 				stubSettings(sandbox);
@@ -273,6 +261,9 @@ describe('Client Created Listener', async () => {
 					.resolves({ statusCode: 200, body: [] });
 
 				mockModelClient();
+
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
 
 				sandbox.spy(ModelClient.prototype, 'save');
 
@@ -312,6 +303,9 @@ describe('Client Created Listener', async () => {
 
 				mockModelClient();
 
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
+
 				sandbox.spy(ModelClient.prototype, 'save');
 
 				stubSettings(sandbox);
@@ -349,6 +343,9 @@ describe('Client Created Listener', async () => {
 					.resolves({ statusCode: 500, body: { message: 'Some API Error' } });
 
 				mockModelClient();
+
+				sandbox.stub(ModelClient, 'additionalFields')
+					.get(() => ['extraField']);
 
 				sandbox.spy(ModelClient.prototype, 'save');
 
@@ -422,10 +419,6 @@ describe('Client Created Listener', async () => {
 
 				delete ClientFormatter.settings;
 
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
-
 				mockModelClient();
 
 				sandbox.stub(ModelClient.prototype, 'save')
@@ -454,23 +447,18 @@ describe('Client Created Listener', async () => {
 
 				assertSecretsGet(sandbox, janisServiceName);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, prepareFakeClient(validEvent.id, true));
-
 				stopMock();
 
 			},
 			responseCode: 200
-		}, {
+		},
+		{
 			description: 'Should return 200 when client model saves the new client successfully without credentials after Secrets Manager throws',
 			event: validEvent,
 			before: sandbox => {
 
 				delete ClientFormatter.settings;
-
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
 
 				mockModelClient();
 
@@ -490,7 +478,6 @@ describe('Client Created Listener', async () => {
 			},
 			after: sandbox => {
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, fakeClient);
 				sandbox.assert.calledOnceWithExactly(MongoDBIndexCreator.prototype.executeForClientCode, validEvent.id);
 				sandbox.assert.calledOnceWithExactly(ListenerCreated.prototype.postSaveHook, validEvent.id, fakeClient);
@@ -505,10 +492,6 @@ describe('Client Created Listener', async () => {
 			before: sandbox => {
 
 				delete ClientFormatter.settings;
-
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
 
 				mockModelClient();
 
@@ -528,7 +511,6 @@ describe('Client Created Listener', async () => {
 			},
 			after: sandbox => {
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, fakeClient);
 				sandbox.assert.calledOnceWithExactly(MongoDBIndexCreator.prototype.executeForClientCode, validEvent.id);
 				sandbox.assert.calledOnceWithExactly(ListenerCreated.prototype.postSaveHook, validEvent.id, fakeClient);
@@ -543,10 +525,6 @@ describe('Client Created Listener', async () => {
 			before: sandbox => {
 
 				delete ClientFormatter.settings;
-
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
 
 				mockModelClient();
 
@@ -571,7 +549,6 @@ describe('Client Created Listener', async () => {
 
 				const expectedSavedClient = prepareFakeClient(validEvent.id, false, false);
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, expectedSavedClient);
 				sandbox.assert.calledOnceWithExactly(MongoDBIndexCreator.prototype.executeForClientCode, validEvent.id);
 				sandbox.assert.calledOnceWithExactly(ListenerCreated.prototype.postSaveHook, validEvent.id, expectedSavedClient);
@@ -586,10 +563,6 @@ describe('Client Created Listener', async () => {
 			before: sandbox => {
 
 				delete ClientFormatter.settings;
-
-				sandbox.stub(MicroserviceCall.prototype, 'safeList')
-					.withArgs('id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 })
-					.resolves({ statusCode: 200, body: [fakeClient] });
 
 				mockModelClient();
 
@@ -617,7 +590,6 @@ describe('Client Created Listener', async () => {
 				const preparedClient = prepareFakeClient(validEvent.id);
 				delete preparedClient.databases.secureDB;
 
-				sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeList, 'id', 'client', { filters: { clientCode: validEvent.id }, limit: 1 });
 				sandbox.assert.calledOnceWithExactly(ModelClient.prototype.save, preparedClient);
 				sandbox.assert.calledOnceWithExactly(MongoDBIndexCreator.prototype.executeForClientCode, validEvent.id);
 				sandbox.assert.calledOnceWithExactly(ListenerCreated.prototype.postSaveHook, validEvent.id, preparedClient);

--- a/tests/listener-updated.js
+++ b/tests/listener-updated.js
@@ -249,10 +249,18 @@ describe('Client Updated Listener', async () => {
 					mockModelClient();
 
 					sandbox.stub(ModelClient, 'additionalFields')
-						.get(() => ['extraField']);
+						.get(() => ['extraField', 'anotherExtraField']);
 
 					sandbox.stub(MicroserviceCall.prototype, 'safeCall')
-						.resolves({ statusCode: 200, body: { ...client, extraField: 'some-data', randomField: 'other-data' } });
+						.resolves({
+							statusCode: 200,
+							body: {
+								...client,
+								extraField: 'some-data',
+								anotherExtraField: 0,
+								randomField: 'other-data'
+							}
+						});
 
 					sandbox.stub(ModelClient.prototype, 'update')
 						.resolves(true);
@@ -261,9 +269,11 @@ describe('Client Updated Listener', async () => {
 				},
 				after: sandbox => {
 
-					sandbox.assert.calledOnceWithExactly(ModelClient.prototype.update, { extraField: 'some-data', status: client.status }, { code: client.code });
+					const clientFieldsToUpdate = { extraField: 'some-data', anotherExtraField: 0 };
+
+					sandbox.assert.calledOnceWithExactly(ModelClient.prototype.update, { ...clientFieldsToUpdate, status: client.status }, { code: client.code });
 					sandbox.assert.calledOnceWithExactly(MicroserviceCall.prototype.safeCall, ...expectedMsCallArgs);
-					sandbox.assert.calledOnceWithExactly(ListenerUpdated.prototype.postSaveHook, { ...client, extraField: 'some-data', randomField: 'other-data' });
+					sandbox.assert.calledOnceWithExactly(ListenerUpdated.prototype.postSaveHook, { ...client, ...clientFieldsToUpdate, randomField: 'other-data' });
 
 					stopMock();
 


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-373

**LINK A LA HISTORIA**
https://fizzmod.atlassian.net/browse/JCN-372

**DESCRIPCIÓN DEL REQUERIMIENTO**
- Se necesita que se puedan guardar (es decir crear o actualizar) datos extras propios del Cliente en JID.
  - Cada Servicio debe poder definir que datos requiere guardar.
  - Si no definien datos extras no debe realizarse ninguna request a JID.
  - Si un dato es borrado en JID, debe borrarse en el servicio.

- Esto se debe hacer para que funcione en:
  - POST/ CLIENTE CREATE 
  - LISTENER/ CLIENTE UPDATE
  - LISTENER/ CLIENTE CREATE

- Logicamente actualizar el README con la nueva caracteristicas 😌 

**DESCRIPCIÓN DE LA SOLUCIÓN**
- Se realizaron los cambios solicitados
- Se hicieron algunas mejoras pequeñas de prolijidad al codigo
- En la clase de la API **Client Created** y Event Listener **Client Created** se le sumó el objeto del cliente creado al segundo parametro del `postSaveHook` ya que puede ser util en futuros desarrollos.